### PR TITLE
Fix path to build.js, fix readme, allow db location to be specified via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fast offline coarse Geocoder based on GeoNames data.
 ## Usage
 
 ```js
-var geocoder = require('geocoder');
+var geocoder = require('geocoder.js');
 
 geocoder('Big Apple', function (location) {
 	/*

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,15 @@
 'use strict';
 
 var _ = require('lodash'),
-	db = require('dblite').withSQLite('3.8.6+')(__dirname + '/../data/geonames.db', '-header'),
+	dblite = require('dblite').withSQLite('3.8.6+'),
 	async = require('async');
+
+var db;
+if (process.env.GEONAMES_SQLITE_DB) {
+	db = dblite(process.env.GEONAMES_SQLITE_DB, '-header');
+} else {
+	db = dblite(__dirname + '/../data/geonames.db', '-header');
+}
 
 db.on('close', function (code) {
 	if (code !== 0) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Fast offline coarse Geocoder",
   "main": "./lib/index.js",
   "bin": {
-    "geocoder.js": "build.js"
+    "geocoder.js": "./data/build.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Fix:

`npm install geocoder.js` fails with 
`npm ERR! enoent ENOENT: no such file or directory, chmod 'E:\Source\Projects\stinahols\node_modules\geocoder.js\build.js`